### PR TITLE
Adds Arduino Nano, Fixes Signal Detect/Transmit Power/Bandwidth

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -59,7 +59,7 @@
   int       loraSpreadingFactor = 8;
   int       loraCodingRate      = 7;
   int       loraTxPower         = 20;
-  uint32_t  loraBandwidth       = 125E6;
+  uint32_t  loraBandwidth       = 125E3;
   uint32_t  loraFrequency       = 43845E4;
 
   uint8_t txBuffer[MTU];
@@ -71,8 +71,6 @@
   bool outboundReady = false;
 
   bool statSignalDetected = false;
-  bool statSignalSynced   = false;
-  bool statRxOngoing      = false;
   bool dcd                = false;
   bool dcdLed             = false;
   bool dcdWaiting         = false;

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,3 +25,9 @@ platform = atmelavr
 board = moteinomega
 framework = arduino
 monitor_speed = 38400
+
+[env:nanoatmega328]
+platform = atmelavr
+board = nanoatmega328  
+framework = arduino
+monitor_speed = 38400

--- a/src/KISSLoRaTNC.cpp
+++ b/src/KISSLoRaTNC.cpp
@@ -99,26 +99,15 @@ void serialCallback(uint8_t txByte) {
 void updateModemStatus() {
   uint8_t status = LoRa.modemStatus();
   lastStatusUpdate = millis();
-  if (status & (SIG_DETECT == 0x01)) {
+  if ((status & SIG_DETECT) != 0) {
     statSignalDetected = true;
+    //Serial.println("SIG_DETECT");
   }
   else {
     statSignalDetected = false;
   }
-  if (status & (SIG_SYNCED == 0x01)) {
-    statSignalSynced = true;
-  }
-  else {
-    statSignalSynced = false;
-  }
-  if (status & (RX_ONGOING == 0x01)) {
-    statRxOngoing = true;
-  }
-  else {
-    statRxOngoing = false;
-  }
 
-  if (statSignalDetected || statSignalSynced || statRxOngoing) {
+  if (statSignalDetected) {
     if (dcdCount < dcdThreshold) {
       dcdCount++;
       dcd = true;
@@ -210,6 +199,7 @@ bool startRadio() {
     Serial.println("SUCCESS");
     LoRa.setSpreadingFactor(loraSpreadingFactor);
     LoRa.setCodingRate4(loraCodingRate);
+    LoRa.setSignalBandwidth(loraBandwidth);
     LoRa.enableCrc();
     LoRa.onReceive(receiveCallback);
     LoRa.receive();

--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -128,7 +128,6 @@ int LoRaClass::begin(long frequency)
   return 1;
 }
 
-
 void LoRaClass::setTxPower(int level, int outputPin)
 {
   if (PA_OUTPUT_RFO_PIN == outputPin) {
@@ -138,20 +137,22 @@ void LoRaClass::setTxPower(int level, int outputPin)
     } else if (level > 14) {
       level = 14;
     }
-    writeRegister(REG_PA_CONFIG, PA_MAX_POWER | (level +1));
+    writeRegister(REG_PA_DAC, PA_DAC_DISABLE);
+    writeRegister(REG_PA_CONFIG, PA_MAX_POWER | level);
   } else {
     // PA BOOST
     if (level < 2) {
       level = 2;
-    } else if (level > 23) {
-      level = 23;
+    } else if (level > 20) {
+      level = 20;
     }
-    if (level > 20) {
+    if (level > 17) {
       writeRegister(REG_PA_DAC, PA_DAC_ENABLE);
       level -= 3;
     } else {
       writeRegister(REG_PA_DAC, PA_DAC_DISABLE);
     }
+    writeRegister(REG_PA_CONFIG, PA_SELECT | (level - 2));
   }
 }
 


### PR DESCRIPTION
platform.io:
Adds and entry for an Arduino Nano

KISSLoraTNC.cpp:
In updateModemStatus(), changed to only look at the Signal Detected bit.
The RX on-going bit is active whenever the chip is in receive mode.
The Signal synchronized bit was redundant.

In startRadio() added setSignalBandwidth() call.
Bandwidth was never being set.

Config.h:
loraBandwidth had the wrong magnitude (was MHz, now is KHz)
Removed unneeded booleans that were used in updateModemStatus()

LoRa.cpp:
setTxPower() was never writing the REG_PA_CONFIG register in PA BOOST mode
Modified setTxPower() to accurately set power levels according to the datasheet
Note: Uncertain how this affects the HamShield:LoRa.