### PR TITLE
LoRa radio parameters can be set/saved via KISS TNC Hardware commands

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -56,11 +56,24 @@
   const int  loraRxTurnaround = 50;
 
   // Default LoRa settings
-  int       loraSpreadingFactor = 8;
-  int       loraCodingRate      = 7;
-  int       loraTxPower         = 20;
-  uint32_t  loraBandwidth       = 125E3;
-  uint32_t  loraFrequency       = 43845E4;
+  struct LoraSettings {
+    int       spreadingFactor;
+    int       codingRate;
+    int       txPower;
+    uint32_t  bandwidth;
+    uint32_t  frequency;
+  };
+
+  LoraSettings loraSettings;
+
+  const int defaultSpreadingFactor = 12; //8;
+  const int defaultCodingRate = 5; //7;
+  const int defaultTxPower = 20;
+  const uint32_t defaultBandwidth = 125E3;
+  const uint32_t defaultFrequency = 433775E3; //43845E4;
+
+  const int settingsAddress = 0;
+  const int crcAddress = settingsAddress + sizeof(LoraSettings);
 
   uint8_t txBuffer[MTU];
   uint8_t rxBuffer[MTU];

--- a/include/KISS.h
+++ b/include/KISS.h
@@ -14,11 +14,19 @@
   #define CMD_HARDWARE      0x06
 
   #define HW_RSSI           0x21
-  
+  #define HW_SF             0x22  // LoRa Spreading Factor - one byte value
+  #define HW_CR             0x23  // LoRa Coding Rate - one byte value
+  #define HW_BW             0x24  // LoRa Bandwidth - four byte value (MSB first)
+  #define HW_POWER          0x25  // LoRa Transmit Power - one byte value
+  #define HW_FREQ           0x26  // LoRa Frequency - four byte value (MSB first)
+  #define HW_SAVE           0x27  // Save hardware parameters in EEPROM
+  #define HW_RESTORE        0x28  // Restore hardware parameters from EEPROM
+
   #define CMD_ERROR         0x90
   #define ERROR_INITRADIO   0x01
   #define ERROR_TXFAILED    0x02
   #define ERROR_QUEUE_FULL  0x04
+  #define ERROR_SETHW       0x05
 
   size_t frameLength;
   bool inFrame                = false;


### PR DESCRIPTION
To experiment with LoRa parameters and not have to recompile the firmware every time, a method to change
the LoRa radio parameters was needed.  Fortunately, the KISS SetHardware command could be used to do this.
Check out KISS.h for details.

Another issue is on Uno and Nano (and maybe other) Arduinos, when the serial port is opened, the processor is reset.
That means if settings were adjusted in one program, the serial port closed, and then another program was used that
opens the serial port, the settings would be lost.  To get around this, settings are now stored in EEPROM (using the basic
Arduino EEPROM library).

This is fine for the ATmega type processors currently supported environments in the platform.io file.  It won't be fine
when other processor types are added.  When they are, the EEPROM code will need to be modified.